### PR TITLE
PointModel 1D is fixed and etc..

### DIFF
--- a/src/java/artisynth_rl_models/src/artisynth/models/rl/RlPoint2PointModel.java
+++ b/src/java/artisynth_rl_models/src/artisynth/models/rl/RlPoint2PointModel.java
@@ -286,10 +286,10 @@ public class RlPoint2PointModel extends RootModel implements RlModelInterface {
 
 	}
 
-	public void add1dMuscles() {
+	public void add1dMuscles(String[] labels) {
 		Log.log("add1dMuscles");
-		boolean[] dyn = new boolean[] { false, true, false };
-		int[] x = new int[] { -1, 0, 1 };
+		boolean[] dyn = new boolean[] { false, false };
+		int[] x = new int[] { -1, 1 };
 
 		ArrayList<Point> pts = new ArrayList<Point>(x.length);
 		for (int i = 0; i < x.length; i++) {
@@ -302,23 +302,16 @@ public class RlPoint2PointModel extends RootModel implements RlModelInterface {
 			pt.setDynamic(dyn[i]);
 			mech.addParticle(pt);
 			pts.add(pt);
-
-			if (x[i] == 0) {
-				// center = pt;
+			addMuscle(pt);
+		}
+		int k = 0;
+		for (AxialSpring m : mech.axialSprings()) {
+			if (m instanceof Muscle) {
+				m.setName(labels[k]);
+				k += 1;
 			}
 		}
-
-		for (int i = 1; i < pts.size(); i++) {
-			AxialSpring m;
-			Point p0 = pts.get(i - 1);
-			Point p1 = pts.get(i);
-			// if (p0==center || p1==center)
-			// m = addAxialSpring(p0, p1);
-			// else
-			m = addMuscle(p0, p1);
-			m.setName("m" + Integer.toString(m.getNumber()));
-		}
-
+				
 	}
 
 	public void addMuscles() {

--- a/src/python/artisynth_envs/envs/point2point_env.py
+++ b/src/python/artisynth_envs/envs/point2point_env.py
@@ -49,9 +49,9 @@ class Point2PointEnvV0(ArtisynthBase):
         self.action_space = type(self).ActionSpace(self.action_size)
 
     def set_state(self, state):
-        self.set_state(state[:3], state[4:])
+        self._set_state(state[:3], state[4:])
 
-    def set_state(self, ref_pos, follower_pos):
+    def _set_state(self, ref_pos, follower_pos):
         self.ref_pos = ref_pos
         self.follower_pos = follower_pos
 
@@ -118,7 +118,7 @@ class Point2PointEnvV0(ArtisynthBase):
 
             distance = self.calculate_distance(new_ref_pos, new_follower_pos)
             if self.prev_distance is not None:
-                reward, done = self.calcualte_reward_time_5(distance,
+                reward, done = self.calculate_reward_time_5(distance,
                                                             self.prev_distance)  # r4
             else:
                 reward, done = (0, False)
@@ -132,7 +132,7 @@ class Point2PointEnvV0(ArtisynthBase):
 
         return state_arr, reward, done, info
 
-    def calcualte_reward_move(self, ref_pos, prev_follow_pos,
+    def calculate_reward_move(self, ref_pos, prev_follow_pos,
                               new_follow_pos):  # r1
         prev_dist = type(self).calculate_distance(ref_pos, prev_follow_pos)
 
@@ -156,7 +156,7 @@ class Point2PointEnvV0(ArtisynthBase):
                     False,
                     10), False
 
-    def calcualte_reward_time_n5(self, new_dist, prev_dist):  # r2
+    def calculate_reward_time_n5(self, new_dist, prev_dist):  # r2
         if new_dist < self.success_thres:
             # achieved done state
             return 5 / self.agent.episode_step, True
@@ -166,7 +166,7 @@ class Point2PointEnvV0(ArtisynthBase):
             else:
                 return -1, False
 
-    def calcualte_reward_time_dist_n5(self, new_dist, prev_dist):  # r3
+    def calculate_reward_time_dist_n5(self, new_dist, prev_dist):  # r3
         if new_dist < self.success_thres:
             # achieved done state
             return 5 / self.agent.episode_step, True
@@ -176,7 +176,7 @@ class Point2PointEnvV0(ArtisynthBase):
             else:
                 return -1, False
 
-    def calcualte_reward_time_5(self, new_dist, prev_dist):  # r4
+    def calculate_reward_time_5(self, new_dist, prev_dist):  # r4
         if new_dist < self.success_thres:
             # achieved done state
             return 5, True
@@ -186,7 +186,7 @@ class Point2PointEnvV0(ArtisynthBase):
             else:
                 return -1, False
 
-    def calcualte_reward_time_dist_nn5(self, new_dist, prev_dist):  # r5
+    def calculate_reward_time_dist_nn5(self, new_dist, prev_dist):  # r5
         if new_dist < self.success_thres:
             # achieved done state
             return 5 / (self.agent.episode_step * new_dist), True

--- a/src/python/main_keras_naf.py
+++ b/src/python/main_keras_naf.py
@@ -124,7 +124,7 @@ def main():
 
     log_file_name = args.model_name
     save_path = os.path.join(config.trained_directory,
-                             args.algo + "-" + args.env_name + ".pt")
+                             args.algo + "-" + args.env_name + ".h5f")
 
     if args.env_name == 'Point2PointEnv-v0':
         env = Point2PointEnvV0(verbose=0, success_thres=args.goal_threshold,
@@ -133,7 +133,7 @@ def main():
                                init_artisynth=args.init_artisynth, artisynth_model=args.artisynth_model,
                                artisynth_args=args.artisynth_args)
     else:
-        raise NotImplementedError("No solution is implemneted for the environment {} in keras-rl.")
+        raise NotImplementedError("No solution is implemented for the environment {} in keras-rl.".format(args.env_name))
     env.seed(123)
 
     try:


### PR DESCRIPTION
1. point model 1d fixed.
2. reward methods were refactored.
3. extension in save model path for pointmodel-naf is changed from ".pt" to ".h5f". 
4. environment name formatting added, incase of no implementation for the environment is available in keras-rl.
5. changed set_state method as private method.